### PR TITLE
fix: layer info generation bug

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -381,5 +381,16 @@ mod test {
                 vec![F::from_canonical_u32(3)]
             ]
         );
+
+        let output_layer_proving_info = circuit.generate_layer_proving_info(1);
+        assert_eq!(
+            output_layer_proving_info,
+            LayerProvingInfo {
+                layer_id: 1,
+                v_subset_instruction: vec![vec![0, 1, 2], vec![3]],
+                add_subsets: vec![vec![], vec![[1, 2, 0]]],
+                mul_subsets: vec![vec![[0, 0, 1]], vec![]]
+            }
+        );
     }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -74,14 +74,13 @@ impl GeneralCircuit {
             ];
 
             v_subset_instruction[norm_left].push(gate.inputs[0].1);
+            let left_sparse_index = v_subset_instruction[norm_left].len() - 1;
+
             v_subset_instruction[norm_right].push(gate.inputs[1].1);
+            let right_sparse_index = v_subset_instruction[norm_right].len() - 1;
 
             // build the add_i / mul_i entry based on v_subset
-            let sparse_entry = [
-                gate_index,
-                v_subset_instruction[norm_left].len() - 1,
-                v_subset_instruction[norm_right].len() - 1,
-            ];
+            let sparse_entry = [gate_index, left_sparse_index, right_sparse_index];
 
             if gate.op == GateOp::Add {
                 add_subsets[norm_left + norm_right].push(sparse_entry);


### PR DESCRIPTION
There was a bug in the layer info generation
- needed to get the sparse index before pushing both inputs, as the length of the subset instruction affects the sparse index. 
- sometimes the norm_left and norm_right might be the same, leading to invalid sparse index if you push all at the same time. 