### PR TITLE
fix: remove input assertion

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -40,9 +40,6 @@ impl GeneralCircuit {
 
     /// Return circuit information needed to run virgo sumcheck
     pub(crate) fn generate_layer_proving_info(&self, layer_id: LayerId) -> LayerProvingInfo {
-        // input: constraint: layer_id cannot point to the input layer
-        assert_ne!(layer_id, self.layers.len() - 1);
-
         // given some global layer id after the target id
         // converts that to the relative id from the target id
         // example: if target_id = i, then layer i + 1 will have


### PR DESCRIPTION
no need to assert layer_id as not input id as layers doesn't contain the input layer at all