### PR TITLE
fix: virgo proof struct

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,7 +4,11 @@ use p3_field::{ExtensionField, Field};
 use poly::Fields;
 use sum_check::primitives::SumCheckProof;
 
+type Hint<F, E> = Fields<F, E>;
+type LayerSumcheck<F, E> = (SumCheckProof<F, E>, Vec<Hint<F, E>>);
+type FoldingSumcheck<F, E> = (SumCheckProof<F, E>, Hint<F, E>);
+
 pub struct VirgoProof<F: Field, E: ExtensionField<F>> {
-    pub layer_sumchecks: (SumCheckProof<F, E>, Vec<Fields<F, E>>),
-    pub folding_sumchecks: (SumCheckProof<F, E>, Fields<F, E>),
+    pub layer_sumchecks: Vec<LayerSumcheck<F, E>>,
+    pub folding_sumchecks: Vec<FoldingSumcheck<F, E>>,
 }


### PR DESCRIPTION
expand to multi layer by taking multiple sumcheck proofs