### PR TITLE
feat: return subclaim

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,4 +1,4 @@
-use crate::util::{push_index, GateAddr, LayerId, LayerProvingInfo};
+use crate::util::{GateAddr, LayerId, LayerProvingInfo, push_index};
 
 #[derive(Debug, Clone)]
 /// Represents a circuit with gates that can have arbitrary wirings
@@ -189,7 +189,7 @@ pub(crate) mod test {
         circuit_builder::Builder,
         util::LayerProvingInfo,
     };
-    use p3_field::{extension::BinomialExtensionField, AbstractField};
+    use p3_field::{AbstractField, extension::BinomialExtensionField};
     use p3_goldilocks::Goldilocks as F;
     use poly::Fields;
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,4 +1,4 @@
-use crate::util::{GateAddr, LayerId, LayerProvingInfo, push_index};
+use crate::util::{push_index, GateAddr, LayerId, LayerProvingInfo};
 
 #[derive(Debug, Clone)]
 /// Represents a circuit with gates that can have arbitrary wirings
@@ -43,7 +43,7 @@ impl GeneralCircuit {
     pub(crate) fn generate_layer_proving_info(&self, layer_id: LayerId) -> LayerProvingInfo {
         // given some global layer id after the target id
         // converts that to the relative id from the target id
-        // example: if target_id = i, then layer i + 1 will have
+        // example: if target_id = i, then layer i + 1 will hav
         // relative id = 0
         let norm_layer_id = |id: LayerId| id - layer_id - 1;
 
@@ -189,7 +189,7 @@ pub(crate) mod test {
         circuit_builder::Builder,
         util::LayerProvingInfo,
     };
-    use p3_field::{AbstractField, extension::BinomialExtensionField};
+    use p3_field::{extension::BinomialExtensionField, AbstractField};
     use p3_goldilocks::Goldilocks as F;
     use poly::Fields;
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -43,7 +43,7 @@ impl GeneralCircuit {
     pub(crate) fn generate_layer_proving_info(&self, layer_id: LayerId) -> LayerProvingInfo {
         // given some global layer id after the target id
         // converts that to the relative id from the target id
-        // example: if target_id = i, then layer i + 1 will hav
+        // example: if target_id = i, then layer i + 1 will have
         // relative id = 0
         let norm_layer_id = |id: LayerId| id - layer_id - 1;
 

--- a/src/protocol/sumcheck/mod.rs
+++ b/src/protocol/sumcheck/mod.rs
@@ -4,7 +4,7 @@ mod phase_two;
 use p3_field::{ExtensionField, Field, PrimeField32};
 use phase_one::prove_phase_one;
 use phase_two::prove_phase_two;
-use poly::{Fields, utils::generate_eq};
+use poly::{utils::generate_eq, Fields};
 use sum_check::primitives::SumCheckProof;
 use transcript::Transcript;
 
@@ -46,11 +46,14 @@ fn merge_sumcheck_proofs<F: Field, E: ExtensionField<F>>(
 
 #[cfg(test)]
 mod test {
-    use crate::{circuit::test::circuit_1, protocol::sumcheck::prove_sumcheck_layer};
-    use p3_field::{AbstractField, ExtensionField, Field, extension::BinomialExtensionField};
+    use crate::{
+        circuit::test::circuit_1, protocol::sumcheck::prove_sumcheck_layer,
+        util::subclaims_to_hints,
+    };
+    use p3_field::{extension::BinomialExtensionField, AbstractField, ExtensionField, Field};
     use p3_mersenne_31::Mersenne31 as F;
-    use poly::{Fields, MultilinearExtension, mle::MultilinearPoly};
-    use sum_check::{SumCheck, interface::SumCheckInterface};
+    use poly::{mle::MultilinearPoly, Fields, MultilinearExtension};
+    use sum_check::{interface::SumCheckInterface, SumCheck};
     use transcript::Transcript;
     type E = BinomialExtensionField<F, 3>;
 
@@ -99,7 +102,8 @@ mod test {
             );
 
             // generate prover hints for oracle check
-            let hints = layer_proving_info_with_subset.eval_subsets(&verification_result.1);
+            let subclaims = layer_proving_info_with_subset.eval_subsets(&verification_result.1);
+            let hints = subclaims_to_hints(&subclaims);
 
             // perform oracle check
             let layer_eval = layer_proving_info.eval(output_point, &hints, &verification_result.1);

--- a/src/protocol/sumcheck/mod.rs
+++ b/src/protocol/sumcheck/mod.rs
@@ -4,7 +4,7 @@ mod phase_two;
 use p3_field::{ExtensionField, Field, PrimeField32};
 use phase_one::prove_phase_one;
 use phase_two::prove_phase_two;
-use poly::{utils::generate_eq, Fields};
+use poly::{Fields, utils::generate_eq};
 use sum_check::primitives::SumCheckProof;
 use transcript::Transcript;
 
@@ -50,10 +50,10 @@ mod test {
         circuit::test::circuit_1, protocol::sumcheck::prove_sumcheck_layer,
         util::subclaims_to_hints,
     };
-    use p3_field::{extension::BinomialExtensionField, AbstractField, ExtensionField, Field};
+    use p3_field::{AbstractField, ExtensionField, Field, extension::BinomialExtensionField};
     use p3_mersenne_31::Mersenne31 as F;
-    use poly::{mle::MultilinearPoly, Fields, MultilinearExtension};
-    use sum_check::{interface::SumCheckInterface, SumCheck};
+    use poly::{Fields, MultilinearExtension, mle::MultilinearPoly};
+    use sum_check::{SumCheck, interface::SumCheckInterface};
     use transcript::Transcript;
     type E = BinomialExtensionField<F, 3>;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,10 +2,10 @@ use std::iter::once;
 
 use p3_field::{ExtensionField, Field};
 use poly::{
+    Fields, MultilinearExtension,
     mle::MultilinearPoly,
     utils::{generate_eq, product_poly},
     vpoly::VPoly,
-    Fields, MultilinearExtension,
 };
 use sum_check::interface::SumCheckInterface;
 
@@ -104,7 +104,8 @@ impl LayerProvingInfo {
         evaluation
     }
 
-    // TODO: add documentation
+    #[allow(dead_code)]
+    /// Given hint and circuit context, constructs subclaims
     pub(crate) fn hints_to_subclaims<F: Field, E: ExtensionField<F>>(
         &self,
         hints: &[Fields<F, E>],
@@ -296,6 +297,7 @@ fn eval_sparse_entry<F: Field, E: ExtensionField<F>>(
     eval
 }
 
+#[allow(dead_code)]
 /// Extract the evaluations from a collection of subclaims
 pub(crate) fn subclaims_to_hints<F: Field, E: ExtensionField<F>>(
     subclaims: &[Subclaim<F, E>],
@@ -307,12 +309,12 @@ pub(crate) fn subclaims_to_hints<F: Field, E: ExtensionField<F>>(
 mod tests {
     use std::vec;
 
-    use p3_field::{extension::BinomialExtensionField, AbstractField, Field};
+    use p3_field::{AbstractField, extension::BinomialExtensionField};
     use p3_mersenne_31::Mersenne31;
     use poly::{
-        mle::MultilinearPoly, utils::product_poly, vpoly::VPoly, Fields, MultilinearExtension,
+        Fields, MultilinearExtension, mle::MultilinearPoly, utils::product_poly, vpoly::VPoly,
     };
-    use sum_check::{interface::SumCheckInterface, SumCheck};
+    use sum_check::{SumCheck, interface::SumCheckInterface};
     use transcript::Transcript;
 
     type F = Mersenne31;
@@ -321,7 +323,7 @@ mod tests {
 
     use crate::{
         circuit::test::circuit_1,
-        util::{build_agi, n_to_1_folding, n_vars_from_len, subclaims_to_hints, Subclaim},
+        util::{Subclaim, build_agi, n_to_1_folding, n_vars_from_len, subclaims_to_hints},
     };
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -285,6 +285,13 @@ fn eval_sparse_entry<F: Field, E: ExtensionField<F>>(
     eval
 }
 
+/// Extract the evaluations from a collection of subclaims
+fn subclaim_to_hints<F: Field, E: ExtensionField<F>>(
+    subclaims: &[Subclaim<F, E>],
+) -> Vec<Fields<F, E>> {
+    subclaims.iter().map(|s| s.eval).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::vec;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,10 +2,10 @@ use std::iter::once;
 
 use p3_field::{ExtensionField, Field};
 use poly::{
-    Fields, MultilinearExtension,
     mle::MultilinearPoly,
     utils::{generate_eq, product_poly},
     vpoly::VPoly,
+    Fields, MultilinearExtension,
 };
 use sum_check::interface::SumCheckInterface;
 
@@ -50,6 +50,7 @@ impl LayerProvingInfo {
 
         LayerProvingInfoWithSubset {
             v_subsets: concrete_subset_values,
+            v_subset_instruction: self.v_subset_instruction,
             add_subsets: self.add_subsets,
             mul_subsets: self.mul_subsets,
         }
@@ -110,6 +111,9 @@ impl LayerProvingInfo {
 pub(crate) struct LayerProvingInfoWithSubset<F: Field, E: ExtensionField<F>> {
     /// Subset values v for some given layer id
     pub(crate) v_subsets: Vec<Vec<Fields<F, E>>>,
+    /// Instructions on how to extract the v subset values
+    /// from an evaluation vector
+    pub(crate) v_subset_instruction: Vec<Vec<usize>>,
     /// Subset add i's based on subset v's
     pub(crate) add_subsets: Vec<Vec<[usize; 3]>>,
     /// Subset mul i's based on subset v's
@@ -234,19 +238,19 @@ fn eval_sparse_entry<F: Field, E: ExtensionField<F>>(
 mod tests {
     use std::vec;
 
-    use p3_field::{AbstractField, extension::BinomialExtensionField};
+    use p3_field::{extension::BinomialExtensionField, AbstractField};
     use p3_mersenne_31::Mersenne31;
     use poly::{
-        Fields, MultilinearExtension, mle::MultilinearPoly, utils::product_poly, vpoly::VPoly,
+        mle::MultilinearPoly, utils::product_poly, vpoly::VPoly, Fields, MultilinearExtension,
     };
-    use sum_check::{SumCheck, interface::SumCheckInterface};
+    use sum_check::{interface::SumCheckInterface, SumCheck};
     use transcript::Transcript;
 
     type F = Mersenne31;
     type E = BinomialExtensionField<F, 3>;
     type S = SumCheck<F, E, VPoly<F, E>>;
 
-    use crate::util::{Subclaim, build_agi, n_to_1_folding, n_vars_from_len};
+    use crate::util::{build_agi, n_to_1_folding, n_vars_from_len, Subclaim};
 
     #[test]
     fn test_n_to_1_folding() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,10 +2,10 @@ use std::iter::once;
 
 use p3_field::{ExtensionField, Field};
 use poly::{
+    Fields, MultilinearExtension,
     mle::MultilinearPoly,
     utils::{generate_eq, product_poly},
     vpoly::VPoly,
-    Fields, MultilinearExtension,
 };
 use sum_check::interface::SumCheckInterface;
 
@@ -296,19 +296,19 @@ fn subclaim_to_hints<F: Field, E: ExtensionField<F>>(
 mod tests {
     use std::vec;
 
-    use p3_field::{extension::BinomialExtensionField, AbstractField};
+    use p3_field::{AbstractField, extension::BinomialExtensionField};
     use p3_mersenne_31::Mersenne31;
     use poly::{
-        mle::MultilinearPoly, utils::product_poly, vpoly::VPoly, Fields, MultilinearExtension,
+        Fields, MultilinearExtension, mle::MultilinearPoly, utils::product_poly, vpoly::VPoly,
     };
-    use sum_check::{interface::SumCheckInterface, SumCheck};
+    use sum_check::{SumCheck, interface::SumCheckInterface};
     use transcript::Transcript;
 
     type F = Mersenne31;
     type E = BinomialExtensionField<F, 3>;
     type S = SumCheck<F, E, VPoly<F, E>>;
 
-    use crate::util::{build_agi, n_to_1_folding, n_vars_from_len, Subclaim};
+    use crate::util::{Subclaim, build_agi, n_to_1_folding, n_vars_from_len};
 
     #[test]
     fn test_n_to_1_folding() {
@@ -327,7 +327,7 @@ mod tests {
             Fields::from_u32_vec(vec![1, 3, 5]),
             Fields::from_u32(0),
         );
-        let c1_subset_instruction = vec![(0, 0), (1, 2), (2, 4)];
+        let c1_subset_instruction = vec![0, 2, 4];
         let c1_r = &all_challenges[..c1_subset_poly.num_vars()];
         let c1_eval = c1_subset_poly.evaluate(c1_r);
         let c1_subclaim = Subclaim {
@@ -340,7 +340,7 @@ mod tests {
             Fields::from_u32_vec(vec![1, 2, 3, 4, 5, 6]),
             Fields::from_u32(0),
         );
-        let c2_subset_instruction = vec![(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)];
+        let c2_subset_instruction = vec![0, 1, 2, 3, 4, 5];
         let c2_r = &all_challenges[..c2_subset_poly.num_vars()];
         let c2_eval = c2_subset_poly.evaluate(c2_r);
         let c2_subclaim = Subclaim {
@@ -353,7 +353,7 @@ mod tests {
             Fields::from_u32_vec(vec![2, 3, 6]),
             Fields::from_u32(0),
         );
-        let c3_subset_instruction = vec![(0, 1), (1, 2), (2, 5)];
+        let c3_subset_instruction = vec![1, 2, 5];
         let c3_r = &all_challenges[..c3_subset_poly.num_vars()];
         let c3_eval = c3_subset_poly.evaluate(c3_r);
         let c3_subclaim = Subclaim {

--- a/src/util.rs
+++ b/src/util.rs
@@ -297,7 +297,7 @@ fn eval_sparse_entry<F: Field, E: ExtensionField<F>>(
 }
 
 /// Extract the evaluations from a collection of subclaims
-fn subclaim_to_hints<F: Field, E: ExtensionField<F>>(
+pub(crate) fn subclaims_to_hints<F: Field, E: ExtensionField<F>>(
     subclaims: &[Subclaim<F, E>],
 ) -> Vec<Fields<F, E>> {
     subclaims.iter().map(|s| s.eval).collect()
@@ -321,7 +321,7 @@ mod tests {
 
     use crate::{
         circuit::test::circuit_1,
-        util::{build_agi, n_to_1_folding, n_vars_from_len, subclaim_to_hints, Subclaim},
+        util::{build_agi, n_to_1_folding, n_vars_from_len, subclaims_to_hints, Subclaim},
     };
 
     #[test]
@@ -437,6 +437,6 @@ mod tests {
         assert_eq!(subclaims[2].r, Fields::from_u32_vec(vec![2]));
         assert_eq!(subclaims[3].r, Fields::from_u32_vec(vec![2]));
 
-        assert_eq!(subclaim_to_hints(&subclaims), hints);
+        assert_eq!(subclaims_to_hints(&subclaims), hints);
     }
 }


### PR DESCRIPTION
Introduces 3 modifications
1. hints_to_subclaims: given a set of hint values and the circuit context can construct the subclaim (this is needed for the verifier)
2. subclaim_to_hints: utility function for the prover to strip unnecessary subclaim info before constructing the virgo proof
3. eval_subset returns subclaims now: this allows the prover to easily generate the n-to-1 folding proof